### PR TITLE
Downgrade to protobuf 4.25.3 

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Thanks to:
 - Meshtastic user FrancisUK1989 for beta testing.
 
 ```
-pip3 install meshtastic paho-mqtt cryptography protobuf
+pip3 install meshtastic paho-mqtt cryptography protobuf==4.25.3
 ```
 
 


### PR DESCRIPTION
Tested this on arch linux
protobuf==4.25.3 # https://pypi.org/project/protobuf/4.25.3/ is needed and not the new 5.26.0 as this breaks it with the following error.

francis@HP-Z8-Fury-G5:~/Desktop/Meshtastic_Parrot-main$ python3 parrot.py

```
Traceback (most recent call last):
  File "/home/francis/Desktop/Meshtastic_Parrot-main/parrot.py", line 4, in <module>
    from meshtastic import mesh_pb2, mqtt_pb2, portnums_pb2
  File "/home/francis/.local/lib/python3.12/site-packages/meshtastic/__init__.py", line 81, in <module>
    from meshtastic import (
  File "/home/francis/.local/lib/python3.12/site-packages/meshtastic/admin_pb2.py", line 5, in <module>
    from google.protobuf.internal import builder as _builder
ImportError: cannot import name 'builder' from 'google.protobuf.internal' (/usr/lib64/python3.12/site-packages/google/protobuf/internal/__init__.py)

```